### PR TITLE
Enables forum links

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -64,12 +64,12 @@ LOAD_LEGACY_RANKS_ONLY
 
 GUEST_BAN
 
-#FORUMURL https://tgstation13.org/phpBB/viewforum.php?f=64
+FORUMURL https://tgstation13.org/phpBB/viewforum.php?f=64
 WIKIURL https://paradisestation.org/tgwiki2/index.php?title=TGMC:TGMC
 RULESURL https://paradisestation.org/tgwiki2/index.php?title=TGMC:Rules
 DISCORDURL https://discord.gg/2dFpfNE
 GITHUBURL https://github.com/tgstation/TerraGov-Marine-Corps/
-#BANAPPEALS https://tgstation13.org/phpBB/viewforum.php?f=70
+BANAPPEALS https://tgstation13.org/phpBB/viewforum.php?f=70
 #DBURL https://tgstation13.org/mcdb/
 
 ## Voting


### PR DESCRIPTION
They're back now so no reason to disable em